### PR TITLE
Update source code, linker script, and build process for RISC-V 32-bit target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install LLD
+        shell: bash
+        run: |
+          sudo unlink /usr/bin/ld
+          sudo ln -s /usr/bin/ld.lld-9 /usr/bin/ld.lld
+          sudo ln -s /usr/bin/ld.lld /usr/bin/ld
+          ls -l /usr/bin | grep ld
+
+      - name: Echo CMake Version
+        shell: bash
+        run: cmake --version
+
+      - name: Echo Clang++ Version
+        shell: bash
+        run:  clang++ --version
+
+      - name: Echo ld Version
+        shell: bash
+        run: ld --version
+
+      - name: Echo lld Version
+        shell: bash
+        run: ld.lld --version
+
       - name: Checkout RKern
         uses: actions/checkout@v2
 
@@ -20,36 +44,21 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build
 
-      - name: Echo CMake Version
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: cmake --version
-
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: CC=clang CXX=clang++ cmake ${GITHUB_WORKSPACE} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGEN_ASM=ON
+        run: CC=clang CXX=clang++ cmake ${GITHUB_WORKSPACE} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DGEN_ASM=ON -DUSE_LLD=ON
 
       - name: Build
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . --config $BUILD_TYPE
 
-      - name: Create metadata.json file
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: |
-          echo "{\"sha1\": \"${RKERN_SHA}\", \"data\": [{\"fileName\": \"kernel.s\", \"fileSize\": $(stat --format='%s' kernel.s)}]}" > metadata.json
-
-      - name: Create Metadata Archive
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: tar -czf metadata.tar.gz metadata.json kernel.s
-
       - name: Run RKern Analyzer Client
         shell: bash
         working-directory: ${{runner.workspace}}/build
         env:
           KEY_JSON_SECRET: ${{ secrets.RKERN_ANALYZER_JSON_KEY_SECRET }}
+          RKA_SERVER: https://rkern-analyzer.uc.r.appspot.com
         run: |
-          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl https://rkern-analyzer.uc.r.appspot.com -metadataArchive metadata.tar.gz
+          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl ${RKA_SERVER} -sha1 ${RKERN_SHA} -kernel rkern.bin kernel.s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,10 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Clang or AppleClang
-    target_compile_options(rkern PUBLIC --target=i686-pc-none-elf)
-    target_link_options(rkern PUBLIC -m32 -static)
+    target_compile_options(rkern PUBLIC -target riscv32-none-elf -march=rv32imac -mno-relax)
+    target_link_options(rkern PUBLIC -target riscv32-none-elf)
     if(USE_LLD)
-        target_link_options(rkern PUBLIC -fuse-ld=lld "LINKER:--script=${PROJECT_SOURCE_DIR}/src/linker.ld")
+        target_link_options(rkern PUBLIC -fuse-ld=ld.lld "LINKER:--script=${PROJECT_SOURCE_DIR}/src/linker.ld")
     else()
         target_link_options(rkern PUBLIC -fuse-ld=ld "LINKER:--script=${PROJECT_SOURCE_DIR}/src/linker.ld")
     endif()
@@ -37,7 +37,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # GCC
     target_compile_options(rkern PUBLIC -m32)
-    target_link_options(rkern PUBLIC -m32 -static "LINKER:--script=${PROJECT_SOURCE_DIR}/src/linker.ld")
+    target_link_options(rkern PUBLIC "LINKER:--script=${PROJECT_SOURCE_DIR}/src/linker.ld")
 endif()
 
 enable_language(ASM)

--- a/notes/notes.bib
+++ b/notes/notes.bib
@@ -2,3 +2,63 @@
 	title = {OSDev.org, a community about the creation of operating systems},
 	url = {https://wiki.osdev.org}
 }
+
+@online{memfaultLinkerScripts,
+	title = {From Zero to main(): Demystifying Firmware Linker Scripts},
+	urldate = {2020-12-03},
+	url = {https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware}
+}
+
+@manual{hifive1RevBBootLoader,
+	title = {SiFive HiFive1 Rev B Getting Started Guide},
+	date = {2020-12-04},
+	version = {1.1},
+	publisher = {SiFive Inc},
+	chapter = {9},
+	pages = {24}
+}
+
+@manual{hifive1RevBBootCode,
+	title = {SiFive FE310-G002 Preliminary Datasheet},
+	date = {2020-12-04},
+	version = {v1p0},
+	publisher = {SiFive Inc},
+	chapter = {5},
+	pages = {11}
+}
+
+@manual{hifive1RevBConfig,
+	title = {SiFive FE310-G002 Preliminary Datasheet},
+	date = {2020-12-04},
+	version = {v1p0},
+	publisher = {SiFive Inc},
+	chapter = {3},
+	pages = {6-8}
+}
+
+@manual{fe310g002manOverview,
+	title = {SiFive FE310-G002 Manual},
+	date = {2020-12-04},
+	version = {v19p04},
+	publisher = {SiFive Inc},
+	chapter = {1},
+	pages = {11-12}
+}
+
+@manual{fe310g002manBootProcess,
+	title = {SiFive FE310-G002 Manual},
+	date = {2020-12-04},
+	version = {v19p04},
+	publisher = {SiFive Inc},
+	chapter = {5},
+	pages = {23-24}
+}
+
+@manual{fe310g002manMMap,
+	title = {SiFive FE310-G002 Manual},
+	date = {2020-12-04},
+	version = {v19p04},
+	publisher = {SiFive Inc},
+	chapter = {4},
+	pages = {22}
+}

--- a/notes/notes.tex
+++ b/notes/notes.tex
@@ -21,43 +21,97 @@
 \usepackage{graphicx}
 %------------------------------
 
-% --------------------
+%------------------------------
 % Bibliography configurations
-% --------------------
+%------------------------------
 \usepackage[backend=biber, sorting=none]{biblatex}
 \bibliography{notes.bib}
+%------------------------------
+
+%------------------------------
+% Customizations for lstlisting package
+%------------------------------
+\usepackage{listings}
+\usepackage[utf8]{inputenc}
+
+\usepackage{xcolor}
+
+\definecolor{codegreen}{rgb}{0,0.6,0}
+\definecolor{codegray}{rgb}{0.5,0.5,0.5}
+\definecolor{codepurple}{rgb}{0.58,0,0.82}
+\definecolor{backcolour}{rgb}{0.95,0.95,0.92}
+
+\lstdefinestyle{mystyle}{
+	backgroundcolor=\color{backcolour},
+	commentstyle=\color{codegreen},
+	keywordstyle=\color{magenta},
+	numberstyle=\tiny\color{codegray},
+	stringstyle=\color{codepurple},
+	basicstyle=\ttfamily\footnotesize,
+	breakatwhitespace=false,
+	breaklines=true,
+	captionpos=b,
+	keepspaces=true,
+	numbers=left,
+	numbersep=5pt,
+	showspaces=false,
+	showstringspaces=false,
+	showtabs=false,
+	tabsize=2
+}
+
+\lstset{style=mystyle}
+%------------------------------
+
+\usepackage{fancyvrb}
+%------------------------------
+
+%------------------------------
+% Table Configurations
+%------------------------------
+\usepackage{multirow}
+% Spacing between cell content and left/right borders
+\setlength{\tabcolsep}{5pt}
+% The height of each row is set to 1.5 relative to its default height.
+\renewcommand{\arraystretch}{1.3}
+
+% This is to be able to have tables stay within the section they are written at.
+\usepackage{float}
+
+\usepackage{longtable}
+%------------------------------
 
 \title{Research Kernel}
 \author{Kian Nejadfard}
 
 \begin{document}
     \maketitle
-    
+
     \begin{abstract}
     	RKern is my new research project for developing a kernel from scratch in C++ to evaluate how the use of zero-overhead abstraction mechanisms can affect a kernel project in terms of codebase maintainability, modularity, usability, and performance.
     \end{abstract}
 
 	\chapter{Preface}
-    
+
 	    \section{Motivation}
 	    	I have always been interested in how software and hardware work together. Naturally this translated into me being curious about kernels. After all, a kernel is the entity that controls and provides mechanisms for accessing resources by user-space software.
-	    	
+
 	    	After going through my master's degree coursework, I became more familiar with topics such as the Linux kernel's programming interface along with how parts of the kernel work internally, the assembly language (I mostly used \textit{NASM}), computer and instruction set architecture, how CPUs work internally, basics of compilers and language design.
-	    	
+
 	    	All of a sudden, I noticed something: the board is set for me to follow two of my lifelong interests. \textit{Developing a kernel from scratch}, and \textit{working with embedded systems}.
 	    	It was at this point that I felt more confident about all of this. I could finally understand what's going on at the hardware level, and what it would take for software to "talk" to hardware.
-	    
+
 	    \section{Goals}
 	        My primary goals for this project and paper are:
 	        \begin{itemize}
 	            \item \textbf{Learn more about the internals of kernels}.
 	            I am a firm believer in learning by doing. Therefore, in my opinion, the best method for learning how kernels work is by making one from scratch. Of course, this is re-inventing a wheel that has been re-invented by many other people so far. However, I see a lot of value in doing this.
-	
-	            \item \textbf{Putting a claim to test: Low-overhead abstraction mechanisms in the kernel}.            
+
+	            \item \textbf{Putting a claim to test: Low-overhead abstraction mechanisms in the kernel}.
 	            Given that I have always been interested in C++ and have worked with this language a lot since the day that I started programming for the first time. I have been searching for reasons why most kernels are developed in C, and not C++. I have a hypothesis that using C++ and its low-overhead abstraction mechanisms can add many values to kernel development. Times have changed since the 1990s, and C++ has evolved a lot. Along with C++, the tooling has also evolved a lot. When searching for an answer to \textit{"Why basically all kernels in use today are developed with C and not C++?"}, I have come across a lot of rants about how unfit C++ is for such a task, how unreliable the C++ compilers are, and similar negative talks. I am putting such arguments to test in this research.
 	            % REFINE THE PREVIOUS PARAGRAPH AND ADD REFERENCES? MAYBE REPHRASE A BIT.
 	        \end{itemize}
-	
+
 	    \section*{Timeline}
 	        The following is a timeline of key events in this project:
 	        \begin{itemize}
@@ -68,34 +122,213 @@
 	            \item \textbf{February 2020} - Changed jobs,
 	            \item \textbf{November 2020} - Started working on the kernel research project again. Chose the name \textit{RKern} for it, and set the project vision.
 	        \end{itemize}
-    
+
     \chapter{Kernels, What They Are, And How They Differ}
-    
+
 	    \section{What Is a Kernel?}
 	    	TODO
-	    
+
 	    \section{Kernel Types}
 	    	TODO
-	    
+
 	    \section{A Brief History}
 	        TODO: review how Unix, Linux, BSDs, etc. were started. Including a timeline, and also review the timeline of Assembly, C, and C++. The idea is to find out if the main reason for today's kernels' use of C is just the time that they started development and the fact that C was the best and only sane choice at the time. Clearly, after decades of development, you can't just change languages of the kernel. So... maybe it is time for a fresh start!
-	
+
     \chapter{Prerequisites And Development Setup}
-    
+
 	    \section{Cross-Compiling}
 	        Since I am compiling the RKern source code on an x86\_64 machine (host) while targeting different architectures (e.g. x86\_32 or RV) (correct wording?), I need to use a cross-compiler.
-	        
+
 	        \subsection{LLVM}
 	        If using the LLVM toolchain, it is much easier to cross-compile to different targets mainly due to the fact that you don't need to setup anything differently. Just the fact that you have LLVM set up means you can use compilation targets other than your host machine.
 	        For example, to use clang++ to compile a C++ source file for i386 architecture, the \verb|--target=i686-pc-none-elf| flag can be used. Similarly, to target the 32-bit RISC-V architecture, \verb|--target=riscv32-unknown-elf| can be used.
-	
+
 			\subsection{GCC}
 	        TODO: add notes for setting up cross-compiler for GCC toolchain.
-	    
+
 	    \section{Building .iso Images}
 	    TODO
 	    Dependencies: grub-mkrescue, xorriso
-    
-    
+
+    \chapter{Binary File Analysis}
+
+        \section{Disassembling The Binary}
+
+            \begin{verbatim}
+llvm-objdump --disassemble-all rkern.bin
+objdump -d rkern.bin
+            \end{verbatim}
+
+    \chapter{Linkers and Linker Scripts}
+
+        \section{What Do Linkers Do?}
+            TODO: use reference http://www.bravegnu.org/gnu-eprog/linker.html
+        
+        \section{Linker Script}
+            A linker script can define 4 pieces of information:
+            \begin{enumerate}
+            	\item \textbf{Memory layout}
+            	\item \textbf{Section definitions} - Defines the structure of the binary file that will be produced by the linker program.
+            	\item \textbf{Options} - Specifications of architecture, entry point, etc. if needed.
+            	\item \textbf{Symbols} - Variables that have to be injected into the program at link time.
+            \end{enumerate}\cite{memfaultLinkerScripts}
+        
+            \subsection{Memory Layout}
+                In order to allocate program space, the linker needs to know how much memory is available, and at what addresses that memory exists. This is what the \verb|MEMORY| definition in the linker script is for.
+                
+                The syntax for \verb|MEMORY| is as follows:
+                \begin{verbatim}
+MEMORY
+{
+    name [(attr)] : ORIGIN = origin, LENGTH = len
+    ...
+}
+                \end{verbatim}
+            	Where:
+            	\begin{itemize}
+            		\item \verb|name| is the region's name. The choice of name is arbitrary as they do not carry any specific meaning. Typical names include \textbf{flash} and \textbf{ram}.
+            		\item \verb|(attr)| are optional attributes for the region, such as \verb|w| (writable), \verb|r| (readable), \verb|x| (executable). Flash memory is usually \verb|rx| while ram is usually \verb|wrx|. Notice that these attributes do not actually set memory, rather they just describe the properties of the memory region.
+            		\item \verb|origin| is the start address of the memory region.
+            		\item \verb|len| is the size of the memory region in bytes.
+            	\end{itemize}
+            
+            \subsection{Section Definitions}
+            
+            \subsection{Options}
+            
+            \subsection{Symbols}
+            
+        \chapter{HiFive1 Rev B}
+            After learning about what linkers do and what a linker script is composed of, we should consult the documentation of the hardware that we want to work with, in order to figure out critical information that we need to use for the compilation and linking process.
+            
+            \section{Gathering Hardware Information}
+            After reviewing the documentations of the \textit{HiFive1 Rev B} board, as well as the \textit{FE310-G002} core that comes with it, I have discovered the following information:
+            \begin{itemize}
+            	\item The FE310-G002 core is configured to support the RV32IMAC ISA options. This specifies the architecture to be used when producing the binary file.\cite{hifive1RevBConfig}
+
+				\item The data SRAM is 16 KiB.\cite{hifive1RevBConfig}
+
+            	\item The system mask ROM is 8 KiB in size and contains simple boot code.\cite{hifive1RevBConfig}
+            	
+            	\item The mask ROM (MROM) is fixed at design time, and is located on the peripheral bus on FE310-G002, but instructions fetched from MROM are cached by the core’s I-cache. The MROM contains an instructionat address 0x10000 which jumps to the OTP start address at 0x20000.\cite{fe310g002manBootProcess}
+            	
+            	\item A dedicated quad-SPI (QSPI) flash interface is provided to hold code and data for the system.The QSPI interface supports burst reads of 32 bytes over TileLink to accelerate instruction cacherefills. The QSPI can be programmed to support eXecute-In-Place modes to reduce SPI commandoverhead on instruction cache refills. The QSPI interface also supports single-word data reads over the primary TileLink interface, as well as programming operations using memory-mappedcontrol registers.\cite{hifive1RevBConfig}
+            	
+            	\item FE310-G002 boots by jumping to the beginning of the OTP memory and executing the code found there. As shipped, the OTP memory at the boot location is programmed to jump immediately to the end of the OTP memory, which in turn jumps to the beginning of the SPI Flash at \textbf{0x20000000}.\cite{hifive1RevBBootCode}
+            	
+            	\item The OTP is located on the peripheral bus, with both a control register interface to program theOTP, and a memory read port interface to fetch words from the OTP. Instruction fetches from theOTP memory read port are cached in the E31 core’s instruction cache.\cite{fe310g002manBootProcess}
+            	
+            	\item The HiFive1 Rev B Board is shipped with a modifiable boot loader at the beginning of SPI Flash(0x20000000). At the end of this program’s execution the core jumps to the main user portion ofcode at \textbf{0x20010000}. This program is designed to allow quick boot, but also a safe rebootoption if a “bad” program is flashed into the SPI Flash. A bad program is one whichmakes it impossible for the programmer to communicate with the board. For example, aprogram which disables FE310’s active clock, or which puts the core to sleep with no way ofwaking it up. Bad programs can always be restarted using the RESET button, and using the“safe” bootloader can be halted before they perform any unsafe behavior.\cite{hifive1RevBBootLoader}
+            	
+            	\item To activate normal boot mode, press the RESET button on the HiFive1 Rev B. After approximately 1 second, the green LED will flash for 1/2 second, then the user program will execute.\cite{hifive1RevBBootLoader}
+            	
+            	\item To activate safe boot mode, press the RESET button. When the green LED flashes, immediately press the RESET button again. After 1 second, the red LED will blink. The user programwill not execute, and the programmer can connect. To exit “safe” boot mode, press the RESETbutton a final time.\cite{hifive1RevBBootLoader}
+            	
+            	\item There are 3 serial peripheral interface (SPI) controllers. Each controller provides a means forserial communication between the FE310-G002 and off-chip devices, like quad-SPI Flash memory. Each controller supports master-only operation over single-lane, dual-lane, and quad-laneprotocols. Each controller supports burst reads of 32 bytes over TileLink to accelerate instruction cache refills. 1 SPI controller can be programmed to support eXecute-In-Place (XIP) modesto reduce SPI command overhead on instruction cache refills.\cite{fe310g002manOverview}
+            	
+            	\item Two universal asynchronous receiver/transmitter (UARTs) are available and provide ameans for serial communication between the FE310-G002 and off-chip devices.\cite{fe310g002manOverview}
+            	
+            	\item The FE310-G002 has an I2C controller to communicate with external I2C devices, such as sensors, ADCs, etc.\cite{fe310g002manOverview}
+            	
+            	\item The FE310-G002 provides external debugger support over an industry-standard JTAG port,including 8 hardware-programmable breakpoints per hart.\cite{fe310g002manOverview}
+            \end{itemize}
+        
+            \section{Memory Map}
+            	The following tables show the FE310-G002 memory map along with relevant attributes:\cite{fe310g002manMMap}
+            	
+            	\begin{table}[H]
+            		\centering
+            		\begin{tabular}{| p{3cm} | c | c | p{3cm} |}
+            			\hline
+            			\textbf{Description} & \textbf{Base} & \textbf{Top} & \textbf{Attributes}\\
+            			\hline
+            			\hline
+            			Debug & 0x0000\_0000 & 0x0000\_0FFF & RWX A\\
+            			\hline
+            		\end{tabular}
+            		\caption{Debug Address Space}
+            	\end{table}
+            
+            	\begin{table}[H]
+            		\centering
+            		\begin{tabular}{| p{4cm} | c | c | p{3cm} |}
+            			\hline
+            			\textbf{Description} & \textbf{Base} & \textbf{Top} & \textbf{Attributes}\\
+            			\hline
+            			Mode Select & 0x0000\_1000 & 0x0000\_1FFF & R XC\\
+            			Reserved & 0x0000\_2000 & 0x0000\_2FFF & \\
+            			Error Device & 0x0000\_3000 & 0x0000\_3FFF & RWX A\\
+            			Reserved & 0x0000\_4000 & 0x0000\_FFFF & \\
+            			Mask ROM & 0x0001\_0000 & 0x0001\_1FFF & R XC\\
+            			Reserved & 0x0001\_2000 & 0x0001\_FFFF & \\
+            			OTP Memory Region & 0x0002\_0000 & 0x0002\_1FFF & R XC\\
+            			Reserved & 0x0002\_2000 & 0x001F\_FFFF & \\
+            			\hline
+            		\end{tabular}
+            		\caption{On-Chip Non Volatile Memory}
+            	\end{table}
+
+                \begin{longtable}[H]{| p{4.5cm} | p{3cm} | p{3cm} | p{2.5cm} |}
+               		\hline
+               		\textbf{Description} & \textbf{Base} & \textbf{Top} & \textbf{Attributes}\\
+               		\hline
+               		\hline
+               		\endfirsthead
+               		CLINT & 0x0200\_0000 & 0x0200\_FFFF & RWA\\
+               		Reserved & 0x0201\_0000 & 0x07FF\_FFFF & \\
+               		E31 ITIM (8 KiB) & 0x0800\_0000 & 0x0800\_1FFF & RWX A\\
+               		Reserved & 0x0800\_2000 & 0x0BFF\_FFFF & \\
+               		PLIC & 0x0C00\_0000 & 0x0FFF\_FFFF & RW A\\
+               		AON & 0x1000\_0000 & 0x1000\_0FFF & RW A\\
+               		Reserved & 0x1000\_1000 & 0x1000\_7FFF & \\
+               		PRCI & 0x1000\_8000 & 0x1000\_8FFF & RW A\\
+               		Reserved & 0x1000\_9000 & 0x1000\_FFFF & \\
+               		OTP Control & 0x1001\_0000 & 0x1001\_0FFF & RW A\\
+               		Reserved & 0x1001\_1000 & 0x1001\_1FFF & \\
+               		GPIO & 0x1001\_2000 & 0x1001\_2FFF & RW A\\
+               		UART 0 & 0x1001\_3000 & 0x1001\_3FFF & RW A\\
+               		QSPI 0 & 0x1001\_4000 & 0x1001\_4FFF & RW A\\
+               		PWM 0 & 0x1001\_5000 & 0x1001\_5FFF & RW A\\
+               		I2C 0 & 0x1001\_6000 & 0x1001\_6FFF & RW A\\
+               		Reserved & 0x1001\_7000 & 0x1002\_2FFF & \\
+               		UART 1 & 0x1002\_3000 & 0x1002\_3FFF & RW A\\
+               		SPI 1 & 0x1002\_4000 & 0x1002\_4FFF & RW A\\
+               		PWM 1 & 0x1002\_5000 & 0x1002\_5FFF & RW A\\
+               		Reserved & 0x1002\_6000 & 0x1003\_3FFF & \\
+               		SPI 2 & 0x1003\_4000 & 0x1003\_4FFF & RW A\\
+               		PWM 2 & 0x1003\_5000 & 0x1003\_5FFF & RW A\\
+               		Reserved & 0x1003\_6000 & 0x1FFF\_FFFF & \\
+               		\hline
+               		\caption{On-Chip Peripherals}
+                \end{longtable}
+            
+            	\begin{table}[H]
+            		\centering
+            		\begin{tabular}{| p{4.5cm} | p{3cm} | p{3cm} | p{2.5cm} |}
+            			\hline
+            			\textbf{Description} & \textbf{Base} & \textbf{Top} & \textbf{Attributes}\\
+            			\hline
+            			\hline
+            			QSPI 0 Flash (512 MiB) & 0x2000\_0000 & 0x3FFF\_FFFF & R XC\\
+            			Reserved & 0x4000\_0000 & 0x7FFF\_FFFF & \\
+            			\hline
+            		\end{tabular}
+            		\caption{Off-Chip Non-volatile Memory}
+            	\end{table}
+            
+            	\begin{table}[H]
+            		\centering
+            		\begin{tabular}{| p{4.5cm} | p{3cm} | p{3cm} | p{2.5cm} |}
+            			\hline
+            			\textbf{Description} & \textbf{Base} & \textbf{Top} & \textbf{Attributes}\\
+            			\hline
+            			\hline
+            			E31 DTIM (16 KiB) & 0x8000\_0000 & 0x8000\_3FFF & RWX A\\
+            			Reserved & 0x8000\_4000 & 0xFFFF\_FFFF & \\
+            			\hline
+            		\end{tabular}
+            		\caption{On-Chip Volatile Memory}
+            	\end{table}
+
     \printbibliography
 \end{document}

--- a/src/boot.asm
+++ b/src/boot.asm
@@ -1,4 +1,6 @@
-/* Declare constants for the multiboot header. */
+/*
+ * Declare constants for the multiboot header.
+ */
 .set ALIGN,    1<<0             /* align loaded modules on page boundaries */
 .set MEMINFO,  1<<1             /* provide memory map */
 .set FLAGS,    ALIGN | MEMINFO  /* this is the Multiboot 'flag' field */
@@ -6,12 +8,12 @@
 .set CHECKSUM, -(MAGIC + FLAGS) /* checksum of above, to prove we are multiboot */
 
 /*
-Declare a multiboot header that marks the program as a kernel. These are magic
-values that are documented in the multiboot standard. The bootloader will
-search for this signature in the first 8 KiB of the kernel file, aligned at a
-32-bit boundary. The signature is in its own section so the header can be
-forced to be within the first 8 KiB of the kernel file.
-*/
+ * Declare a multiboot header that marks the program as a kernel. These are magic
+ * values that are documented in the multiboot standard. The bootloader will
+ * search for this signature in the first 8 KiB of the kernel file, aligned at a
+ * 32-bit boundary. The signature is in its own section so the header can be
+ * forced to be within the first 8 KiB of the kernel file.
+ */
 .section .multiboot
 .align 4
 .long MAGIC
@@ -19,17 +21,17 @@ forced to be within the first 8 KiB of the kernel file.
 .long CHECKSUM
 
 /*
-The multiboot standard does not define the value of the stack pointer register
-(esp) and it is up to the kernel to provide a stack. This allocates room for a
-small stack by creating a symbol at the bottom of it, then allocating 16384
-bytes for it, and finally creating a symbol at the top. The stack grows
-downwards on x86. The stack is in its own section so it can be marked nobits,
-which means the kernel file is smaller because it does not contain an
-uninitialized stack. The stack on x86 must be 16-byte aligned according to the
-System V ABI standard and de-facto extensions. The compiler will assume the
-stack is properly aligned and failure to align the stack will result in
-undefined behavior.
-*/
+ * The multiboot standard does not define the value of the stack pointer register
+ * (esp) and it is up to the kernel to provide a stack. This allocates room for a
+ * small stack by creating a symbol at the bottom of it, then allocating 16384
+ * bytes for it, and finally creating a symbol at the top. The stack grows
+ * downwards on x86. The stack is in its own section so it can be marked nobits,
+ * which means the kernel file is smaller because it does not contain an
+ * uninitialized stack. The stack on x86 must be 16-byte aligned according to the
+ * System V ABI standard and de-facto extensions. The compiler will assume the
+ * stack is properly aligned and failure to align the stack will result in
+ * undefined behavior.
+ */
 .section .bss
 .align 16
 stack_bottom:
@@ -37,73 +39,48 @@ stack_bottom:
 stack_top:
 
 /*
-The linker script specifies _start as the entry point to the kernel and the
-bootloader will jump to this position once the kernel has been loaded. It
-doesn't make sense to return from this function as the bootloader is gone.
-*/
+ * The linker script specifies _start as the entry point to the kernel and the
+ * bootloader will jump to this position once the kernel has been loaded. It
+ * doesn't make sense to return from this function as the bootloader is gone.
+ */
 .section .text
-.global _start
+.globl _start
 .type _start, @function
 _start:
-	/*
-	The bootloader has loaded us into 32-bit protected mode on a x86
-	machine. Interrupts are disabled. Paging is disabled. The processor
-	state is as defined in the multiboot standard. The kernel has full
-	control of the CPU. The kernel can only make use of hardware features
-	and any code it provides as part of itself. There's no printf
-	function, unless the kernel provides its own <stdio.h> header and a
-	printf implementation. There are no security restrictions, no
-	safeguards, no debugging mechanisms, only what the kernel provides
-	itself. It has absolute and complete power over the
-	machine.
-	*/
+    /*
+     * Setup stack
+     */
+    la sp, stack_top
 
-	/*
-	To set up a stack, we set the esp register to point to the top of the
-	stack (as it grows downwards on x86 systems). This is necessarily done
-	in assembly as languages such as C cannot function without a stack.
-	*/
-	mov $stack_top, %esp
+    /*
+     * This is a good place to initialize crucial processor state before the
+     * high-level kernel is entered. It's best to minimize the early
+     * environment where crucial features are offline. Note that the
+     * processor is not fully initialized yet: Features such as floating
+     * point instructions and instruction set extensions are not initialized
+     * yet. The GDT should be loaded here. Paging should be enabled here.
+     * C++ features such as global constructors and exceptions will require
+     * runtime support to work as well.
+     */
 
-	/*
-	This is a good place to initialize crucial processor state before the
-	high-level kernel is entered. It's best to minimize the early
-	environment where crucial features are offline. Note that the
-	processor is not fully initialized yet: Features such as floating
-	point instructions and instruction set extensions are not initialized
-	yet. The GDT should be loaded here. Paging should be enabled here.
-	C++ features such as global constructors and exceptions will require
-	runtime support to work as well.
-	*/
+    /*
+     * Enter the high-level kernel. The ABI requires the stack is 16-byte
+     * aligned at the time of the call instruction (which afterwards pushes
+     * the return pointer of size 4 bytes). The stack was originally 16-byte
+     * aligned above and we've since pushed a multiple of 16 bytes to the
+     * stack since (pushed 0 bytes so far) and the alignment is thus
+     * preserved and the call is well defined.
+     */
+    call kernel_main
 
-	/*
-	Enter the high-level kernel. The ABI requires the stack is 16-byte
-	aligned at the time of the call instruction (which afterwards pushes
-	the return pointer of size 4 bytes). The stack was originally 16-byte
-	aligned above and we've since pushed a multiple of 16 bytes to the
-	stack since (pushed 0 bytes so far) and the alignment is thus
-	preserved and the call is well defined.
-	*/
-	call kernel_main
-
-	/*
-	If the system has nothing more to do, put the computer into an
-	infinite loop. To do that:
-	1) Disable interrupts with cli (clear interrupt enable in eflags).
-	   They are already disabled by the bootloader, so this is not needed.
-	   Mind that you might later enable interrupts and return from
-	   kernel_main (which is sort of nonsensical to do).
-	2) Wait for the next interrupt to arrive with hlt (halt instruction).
-	   Since they are disabled, this will lock up the computer.
-	3) Jump to the hlt instruction if it ever wakes up due to a
-	   non-maskable interrupt occurring or due to system management mode.
-	*/
-	cli
-1:	hlt
-	jmp 1b
+    /*
+     * Go into an infinite loop if the kernel has nothing else to do.
+     */
+1:  wfi
+    j 1b
 
 /*
-Set the size of the _start symbol to the current location '.' minus its start.
-This is useful when debugging or when you implement call tracing.
-*/
+ * Set the size of the _start symbol to the current location '.' minus its start.
+ * This is useful when debugging or call tracing is implemented.
+ */
 .size _start, . - _start

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -3,11 +3,6 @@
   #error "Not using a cross-compiler. This is probably a bad idea."
 #endif
 
-// Currently rkern only works for 32-bit ix86 targets.
-#if !defined(__i386__)
-  #error "This tutorial needs to be compiled with a ix86-elf compiler"
-#endif
-
 #include "types.hpp"
 #include "vga.hpp"
 #include "utility.hpp"

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -1,43 +1,60 @@
-/* The bootloader will look at this image and start execution at the symbol
-   designated as the entry point. */
+OUTPUT_ARCH(riscv)
+
+/*
+ * The bootloader will look at this image and start execution at the symbol
+ * designated as the entry point.
+ */
 ENTRY(_start)
 
-/* Tell where the various sections of the object files will be put in the final
-   kernel image. */
+MEMORY
+{
+    flash (rx) : ORIGIN = 0x20010000, LENGTH = 0x6a120
+    ram (rwxa) : ORIGIN = 0x80000000, LENGTH = 0x4000
+}
+
 SECTIONS
 {
-	/* Begin putting sections at 1 MiB, a conventional place for kernels to be
-	   loaded at by the bootloader. */
-	. = 1M;
-
-	/* First put the multiboot header, as it is required to be put very early
-	   early in the image or the bootloader won't recognize the file format.
-	   Next we'll put the .text section. */
-	.text : ALIGN(4K)
+    /*
+     * First put the multiboot header, as it is required to be put very early
+     * early in the image or the bootloader won't recognize the file format.
+     * Next we'll put the .text section.
+     */
+	.text : ALIGN(4)
 	{
 		*(.multiboot)
 		*(.text)
-	}
+	} >flash
+
+    /*
+     * The start of flash data is right after all of code in flash.
+     */
+    flash_sdata = .;
 
 	/* Read-only data. */
-	.rodata : ALIGN(4K)
+	.rodata : ALIGN(4)
 	{
 		*(.rodata)
-	}
+	} >flash
 
-	/* Read-write data (initialized) */
-	.data : ALIGN(4K)
+	/*
+     * Read-write data (initialized)
+     */
+	.data : ALIGN(4)
 	{
 		*(.data)
-	}
+	} >ram
 
-	/* Read-write data (uninitialized) and stack */
-	.bss : ALIGN(4K)
+	/*
+     * Read-write data (uninitialized) and stack
+     */
+	.bss : ALIGN(4)
 	{
 		*(COMMON)
 		*(.bss)
-	}
+	} >ram
 
-	/* The compiler may produce other sections, by default it will put them in
-	   a segment with the same name. Simply add stuff here as needed. */
+	/*
+     * The compiler may produce other sections, by default it will put them in
+     * a segment with the same name. Simply add stuff here as needed.
+     */
 }


### PR DESCRIPTION
- Add HiFive1 Rev B information from manuals
- Remove i386 enforcement macro
- Cleanup linker script and adjust according to HiFive1 Rev B manuals
- Rewrite kernel boot code to adapt to RISC-V assembly instructions
- Update LLVM compiler and linker flags for riscv32-none-elf target triple
- Update continuous integration config

Generating the .tar.gz archive for analysis is now being handled
by the client program.

In addition, the CI build steps have been re-organized and modified
to use LLVM's LLD for linking. In future, a CI build using GNU tools
should be added.