### PR TITLE
Reduce stack size and stack alignment

### DIFF
--- a/src/boot.asm
+++ b/src/boot.asm
@@ -33,9 +33,9 @@
  * undefined behavior.
  */
 .section .bss
-.align 16
+.align 4
 stack_bottom:
-.skip 16384 # 16 KiB
+.skip 64 # 64 Bytes
 stack_top:
 
 /*


### PR DESCRIPTION
Given the target systems of this kernel being embedded solutions,
and the initial test board to be used for runnign this kernel, the
stack size is being reduced to 64 bytes, with 4-byte alignment.

Closes #23 