### PR TITLE
Upload linker map file in CI build for analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
           KEY_JSON_SECRET: ${{ secrets.RKERN_ANALYZER_JSON_KEY_SECRET }}
           RKA_SERVER: https://rkern-analyzer.uc.r.appspot.com
         run: |
-          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl ${RKA_SERVER} -sha1 ${RKERN_SHA} -kernel rkern.bin link.map kernel.s
+          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl ${RKA_SERVER} -sha1 ${RKERN_SHA} -kernel rkern.bin -linkerMapFile link.map kernel.s


### PR DESCRIPTION
Using the updated rka_client program, the CI build process now produces and uploads the map file generated by linker.