### PR TITLE
Update RKern Analyzer client to preserve original linker map content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
           KEY_JSON_SECRET: ${{ secrets.RKERN_ANALYZER_JSON_KEY_SECRET }}
           RKA_SERVER: https://rkern-analyzer.uc.r.appspot.com
         run: |
-          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl ${RKA_SERVER} -sha1 ${RKERN_SHA} -kernel rkern.bin -linkerMapFile link.map kernel.s
+          ${GITHUB_WORKSPACE}/.github/workflows/rka_client -keyPath ${GITHUB_WORKSPACE}/.github/workflows/key.json.asc -rkaBaseUrl ${RKA_SERVER} -sha1 ${RKERN_SHA} -kernel rkern.bin -linkerMapFile linker_map.txt kernel.s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 if(GEN_LINK_MAP)
     # the following compiler flag is acceptable by both GCC and LLVM
-    target_link_options(rkern PRIVATE "LINKER:--Map,link.map")
+    target_link_options(rkern PRIVATE "LINKER:--Map,linker_map.txt")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
The updated rka_client uploads the linker map file content as-is, as
opposed to translating it into a JSON payload before creating the
snapshot archive.
Also, it is now able to save the binary kernel file and info in snapshot.